### PR TITLE
Replace \Exception with \InvalidArgumentException

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -735,7 +735,7 @@ class Service
     public function get($key)
     {
         if (!property_exists($this, $key)) {
-            throw new \Exception('Unknown Service property: ' . $key);
+            throw new \InvalidArgumentException('Unknown Service property: ' . $key);
         }
         return $this->{$key};
     }
@@ -746,7 +746,7 @@ class Service
     public function set($key)
     {
         if (!property_exists($this, $key)) {
-            throw new \Exception('Unknown Service property: ' . $key);
+            throw new \InvalidArgumentException('Unknown Service property: ' . $key);
         }
         return $this->{$key};
     }


### PR DESCRIPTION
Instead of using generic \Exception you should rather use php-level \InvalidArgumentException as it describes better what type of Exception you deal with.